### PR TITLE
Copter 4.2.3 fwks selective start

### DIFF
--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#define FLYWORKS_CUSTOM_VERSION "v423.05" // must be less than 7 chars (leave 1 char space for terminating null)
+#define FLYWORKS_CUSTOM_VERSION "v423.06" // must be less than 7 chars (leave 1 char space for terminating null)
 
 class PACKED AP_FWVersion {
 

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#define FLYWORKS_CUSTOM_VERSION "v423.04" // must be less than 7 chars (leave 1 char space for terminating null)
+#define FLYWORKS_CUSTOM_VERSION "v423.05" // must be less than 7 chars (leave 1 char space for terminating null)
 
 class PACKED AP_FWVersion {
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -159,6 +159,7 @@ void AP_MotorsMatrix::output_to_motors()
     int8_t i;
 
      bool output_ice = true;
+     bool output_alt = false;
     _ignt_mode=false;
 
     switch (_spool_state) {
@@ -194,6 +195,10 @@ void AP_MotorsMatrix::output_to_motors()
                             _actuator[i] = ign_pass_norm;
                             }
                         }
+
+                        //output same command to alternator actuator #73
+                        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, int16_t(ign_pass_norm*100));
+                        output_alt=true;
                     }
                     else{
                         for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
@@ -201,6 +206,7 @@ void AP_MotorsMatrix::output_to_motors()
                                 _actuator[i] = 0.0f;
                             }
                         }
+
                     }
             break;
         }
@@ -242,6 +248,12 @@ void AP_MotorsMatrix::output_to_motors()
         ice_out = 0;
     }
     SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, int16_t(ice_out));
+
+    if(!output_alt){
+        //output 0 command to alternator actuator #73
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, int16_t(0));
+    }
+    
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -190,7 +190,7 @@ void AP_MotorsMatrix::output_to_motors()
 
                         //output the passthrough channel value to all active motors
                         for (i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
-                            if (motor_enabled[i]) {
+                            if (motor_enabled[i] && ((_ICE_start_motors>>i) & 1)) {
                             _actuator[i] = ign_pass_norm;
                             }
                         }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -301,6 +301,14 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("AUX_IDL_TH", 53, AP_MotorsMulticopter, _aux_ground_idle, 0.025),
 
+    // @Param: ICE_STR_BM
+    // @DisplayName: BITMASK WHAT MOTORS ARE USED FOR ENGINE START
+    // @Description: Bitmask for stating what motors are used for engine start
+    // @Range: 0 256
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("ICE_STR_BM", 54, AP_MotorsMulticopter, _ICE_start_motors, 0),
+
     /* END OF THROTTLE SPLIT PARAMS */   
 
     AP_GROUPEND

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -190,6 +190,7 @@ protected:
     AP_Float            _ice_min_arm;           // minimum allowed ice throttle while armed
     AP_Float            _ice_ground_idle;       //ice throttle while idling on ground
     AP_Float            _aux_ground_idle;       //aux throttle while idling on ground
+    AP_Int16            _ICE_start_motors;      //bitmask stating what motors are used for ICE engine start
     bool                _ice_wait_reset = true;       //output 0 to ice after disarming. This can be reset by running the ice_in_ch through 0
 
     // scaling for booster motor throttle


### PR DESCRIPTION
add the selective start feature
able to send the engine start command only on selected output channels