### PR TITLE
Copter 4.2.3 fwks pair spinup

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -13,7 +13,7 @@
 #define THRUST_LOSS_CHECK_MINIMUM_THROTTLE    0.9f  // we can expect to maintain altitude above 90 % throttle
 
 // Yaw imbalance check
-#define YAW_IMBALANCE_IMAX_THRESHOLD 0.75f
+#define YAW_IMBALANCE_IMAX_THRESHOLD 0.005f
 #define YAW_IMBALANCE_WARN_MS 10000
 
 // crash_check - disarms motors if a crash has been detected

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -14,7 +14,7 @@
 
 // Yaw imbalance check
 #define YAW_IMBALANCE_IMAX_THRESHOLD 0.005f
-#define YAW_IMBALANCE_WARN_MS 10000
+#define YAW_IMBALANCE_WARN_MS 7500
 
 // crash_check - disarms motors if a crash has been detected
 // crashes are detected by the vehicle being more than 20 degrees beyond it's angle limits continuously for more than 1 second
@@ -224,7 +224,7 @@ void Copter::yaw_imbalance_check()
         const uint32_t now = millis();
         if (now - last_yaw_warn_ms > YAW_IMBALANCE_WARN_MS) {
             last_yaw_warn_ms = now;
-            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Yaw Imbalance %0.0f%%", I *100);
+            gcs().send_text(MAV_SEVERITY_EMERGENCY, "Yaw Imbalance %0.00f%%", I *100);
         }
     }
 }

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#define FLYWORKS_CUSTOM_VERSION "v423.07" // must be less than 7 chars (leave 1 char space for terminating null)
+#define FLYWORKS_CUSTOM_VERSION "v423.08" // must be less than 7 chars (leave 1 char space for terminating null)
 
 class PACKED AP_FWVersion {
 

--- a/libraries/AP_Common/AP_FWVersion.h
+++ b/libraries/AP_Common/AP_FWVersion.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
-#define FLYWORKS_CUSTOM_VERSION "v423.06" // must be less than 7 chars (leave 1 char space for terminating null)
+#define FLYWORKS_CUSTOM_VERSION "v423.07" // must be less than 7 chars (leave 1 char space for terminating null)
 
 class PACKED AP_FWVersion {
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -583,7 +583,7 @@ bool AP_MotorsMatrix::ice_compute_output(float & ice_out)
 
      //handle mix_mode GCS messages
 
-   if (!(_ice_mix_mode==2)){
+   if (!((_ice_mix_mode==2)||(_ice_mix_mode==6))){
         if(GCS_message_mixmode==1){
             GCS_message_mixmode=3;
         }else{
@@ -600,11 +600,11 @@ bool AP_MotorsMatrix::ice_compute_output(float & ice_out)
                     gcs().send_text(MAV_SEVERITY_WARNING, "ICE output frozen - reset ICE input");
                     break;
                 } case 2: { 
-                    gcs().send_text(MAV_SEVERITY_INFO, "mix mode is not 2");
+                    gcs().send_text(MAV_SEVERITY_INFO, "mix mode is not 2 or 6");
                     break;
                 } case 3: { 
                     gcs().send_text(MAV_SEVERITY_WARNING, "ICE output frozen - reset ICE input");
-                    gcs().send_text(MAV_SEVERITY_INFO, "mix mode is not 2");
+                    gcs().send_text(MAV_SEVERITY_INFO, "mix mode is not 2 or 6");
                     break;
                 }default: {
                     break;

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -295,7 +295,7 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     roll_thrust = (_roll_in + _roll_in_ff) * compensation_gain;
     pitch_thrust = (_pitch_in + _pitch_in_ff) * compensation_gain;
     yaw_thrust = (_yaw_in + _yaw_in_ff) * compensation_gain;
-    if (_ice_mix_mode>=2 && _ice_mix_mode<=5) throttle_thrust = get_throttle_split_aux() * compensation_gain;
+    if (_ice_mix_mode>=2 && _ice_mix_mode<=6) throttle_thrust = get_throttle_split_aux() * compensation_gain;
     else throttle_thrust = get_throttle() * compensation_gain;
     throttle_avg_max = _throttle_avg_max * compensation_gain;
 
@@ -570,7 +570,10 @@ bool AP_MotorsMatrix::ice_compute_output(float & ice_out)
                 } case 5: { // Mode 3 Throttle Split Ground testing
                     ice_in_slew = get_booster_throttle();
                     break;
-                } default: {
+                } case 6: { // Mode 3 Throttle Split Ground testing
+                    ice_in_slew = get_booster_throttle();
+                    break;
+                }default: {
                     return false;
                 }
             }
@@ -627,16 +630,29 @@ float AP_MotorsMatrix::get_throttle_split_main()
     float curr_throttle=get_throttle();
     float th_split_main_out=0.0f;
 
-    if(_ice_mix_mode==2||_ice_mix_mode==4){
-        th_split_main_out= linear_interpolate(
+
+    switch (_ice_mix_mode){
+        case 2:{
+            th_split_main_out= linear_interpolate(
                 _ice_min_arm,
                 _ice_sat_out,
                 curr_throttle,
                 0.0,
                 1.0);
-
-    }else{
-        if(curr_throttle<=_sat_point_main){
+                break;
+        }case 4:{
+            th_split_main_out= linear_interpolate(
+                _ice_min_arm,
+                _ice_sat_out,
+                curr_throttle,
+                0.0,
+                1.0);
+                break;
+        }case 6:{
+            th_split_main_out= curr_throttle;
+                    break;
+        }default:{
+            if(curr_throttle<=_sat_point_main){
             th_split_main_out= linear_interpolate(
                 _ice_min_arm,
                 _ice_sat_out,
@@ -644,13 +660,14 @@ float AP_MotorsMatrix::get_throttle_split_main()
                 0.0,
                 _sat_point_main);
 
-        } else {
-            th_split_main_out = linear_interpolate(
-                _ice_sat_out,
-                1.0,
-                curr_throttle,
-                _sat_point_main,
-                1.0);
+            } else {
+                th_split_main_out = linear_interpolate(
+                    _ice_sat_out,
+                    1.0,
+                    curr_throttle,
+                    _sat_point_main,
+                    1.0);
+            }
         }
     }
 
@@ -662,30 +679,43 @@ float AP_MotorsMatrix::get_throttle_split_aux()
     float curr_throttle=get_throttle();
     float th_split_aux_out=0.0f;
 
-    if(_ice_mix_mode==2||_ice_mix_mode==4){
-        th_split_aux_out= linear_interpolate(
-                _min_thr_aux,
-                _max_thr_aux,
-                curr_throttle,
-                0.0,
-                1.0);
-
-    }else{
-        if(curr_throttle<=_sat_point_main){
+    switch (_ice_mix_mode){
+        case 2:{
             th_split_aux_out= linear_interpolate(
-                _min_thr_aux,
-                _max_thr_aux,
-                curr_throttle,
-                0.0,
-                _sat_point_main);
-
-        } else {
+                    _min_thr_aux,
+                    _max_thr_aux,
+                    curr_throttle,
+                    0.0,
+                    1.0);
+                    break;
+        }case 4:{
             th_split_aux_out= linear_interpolate(
-                _max_thr_aux,
-                1.0,
-                curr_throttle,
-                _sat_point_main,
-                1.0);
+                    _min_thr_aux,
+                    _max_thr_aux,
+                    curr_throttle,
+                    0.0,
+                    1.0);
+                    break;
+        }case 6:{
+            th_split_aux_out= _min_thr_aux;
+                    break;
+        }default:{
+            if(curr_throttle<=_sat_point_main){
+                th_split_aux_out= linear_interpolate(
+                    _min_thr_aux,
+                    _max_thr_aux,
+                    curr_throttle,
+                    0.0,
+                    _sat_point_main);
+
+            } else {
+                th_split_aux_out= linear_interpolate(
+                    _max_thr_aux,
+                    1.0,
+                    curr_throttle,
+                    _sat_point_main,
+                    1.0);
+            }
         }
     }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -153,6 +153,11 @@ protected:
 private:
     static AP_MotorsMatrix *_singleton;
 
+    //spinup parameters
+    uint64_t _spinup_timer=0;
+    uint16_t _spinup_BM=0;
+    #define _spinup_cap 1500
+
 
     // ice functions
     bool ice_compute_output(float & ice_out);


### PR DESCRIPTION
Add support to spinup the motor in pairs during arming. This lightens the load on the main ICE.